### PR TITLE
Updated to print company name alongside respective invoice

### DIFF
--- a/CsharpExample/CsharpExample/Program.cs
+++ b/CsharpExample/CsharpExample/Program.cs
@@ -11,36 +11,48 @@ namespace LockstepExamples // Note: actual namespace depends on the project name
     {
         public static async Task Main(string[] args)
         {
-            var client = LockstepApi
-                .WithEnvironment(LockstepEnv.SBX);
+            var client = LockstepApi.WithEnvironment(LockstepEnv.SBX);
             var apiKey = Environment.GetEnvironmentVariable("LOCKSTEPAPI_SBX");
+            
             if (apiKey != null)
             {
                 client.WithApiKey(apiKey);
             }
+            
             var result = await client.Status.Ping();
-            
             Console.WriteLine("Ping result: " + JsonSerializer.Serialize(result));
-            
+
             var pageNumber = 0;
             var count = 0;
             
             while (true)
             {
-                var invoices = await client.Invoices.QueryInvoices("invoiceDate > 2021-12-01", null, "invoiceDate asc", 100, pageNumber);
+                // Single API call to fetch invoices and company info.
+                // Pass "Customer" instead of "Company" into the "include" parameter
+                // because "Company" was returning the main CompanyName "Lockstep Demo Data"
+                // instead of each individual invoice's company name.
+                var invoices = await client.Invoices.QueryInvoices(
+                    "invoiceDate > 2021-12-01", 
+                    "Customer", 
+                    "invoiceDate asc", 
+                    100, 
+                    pageNumber
+                );
+
                 if (!invoices.Success || invoices.Value.Records.Length == 0)
                 {
                     break;
                 }
+                
                 foreach (var invoice in invoices.Value.Records)
                 {
                     Console.WriteLine($"Invoice {count++}: {invoice.InvoiceId}");
+                    Console.WriteLine($"Company Name: {invoice.Customer.CompanyName}");
+                    Console.WriteLine(); // Space for readability.
                 }
 
                 pageNumber++;
             }
-            
-            
         }
     }
 }


### PR DESCRIPTION
Sample C# program now prints invoice id and its respective company name. 
Added comments to explain why `Customer` was used instead of `Company` under the `include` parameter in the query.
Fixed some formatting throughout code (may be a nit, please correct as needed)!

Screenshot (console):
![console](https://user-images.githubusercontent.com/36486525/149405693-45362371-25b5-447e-9565-7c87bd21175f.png)