### PR TITLE
Clean up C# projects

### DIFF
--- a/CsharpExample/CollectionsReport/CollectionsReport.csproj
+++ b/CsharpExample/CollectionsReport/CollectionsReport.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="CsvHelper" Version="27.2.1" />
-      <PackageReference Include="LockstepSdk" Version="2022.9.56" />
+      <PackageReference Include="CSVFile" Version="3.0.9" />
+      <PackageReference Include="LockstepSdk" Version="2022.11.60" />
     </ItemGroup>
 
 </Project>

--- a/CsharpExample/CollectionsReport/Program.cs
+++ b/CsharpExample/CollectionsReport/Program.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
-using System.Text.Json;
 using System.Threading.Tasks;
+using CSVFile;
 using LockstepSDK;
-using CsvHelper;
 
 // I would like to see a sample program that shows how to query for invoices with an outstanding balance older than a certain age,
 // then fetch the primary contact person for that invoice, and export the list to CSV
@@ -63,17 +61,10 @@ namespace LockstepExamples // Note: actual namespace depends on the project name
                     }));
                 }
                 
-                var currentDirectory = Directory.GetCurrentDirectory();
-                const string fileName = "Results.csv";
-                var filePath = $"{currentDirectory}\\..\\..\\..\\{fileName}";
-
+                var filePath = Path.GetTempFileName();
                 try
                 {
-                    await using (var writer = new StreamWriter($"{filePath}"))
-                    await using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
-                    {
-                        await csv.WriteRecordsAsync(entries);
-                    }
+                    await File.WriteAllTextAsync(filePath, CSV.Serialize(entries));
                 }
                 catch (Exception e)
                 {
@@ -90,7 +81,7 @@ namespace LockstepExamples // Note: actual namespace depends on the project name
     public class Entry
     {
         public Guid? InvoiceId { get; set; }
-        public DateTime? InvoiceDate { get; set; }
+        public string? InvoiceDate { get; set; }
         public double? OutstandingBalance { get; set; }
         public string? PrimaryContact { get; set; }
     }

--- a/CsharpExample/CompanyReport/CompanyReport.csproj
+++ b/CsharpExample/CompanyReport/CompanyReport.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="CsvHelper" Version="27.2.1" />
-      <PackageReference Include="LockstepSdk" Version="2022.9.56" />
+      <PackageReference Include="CSVFile" Version="3.0.9" />
+      <PackageReference Include="LockstepSdk" Version="2022.11.60" />
     </ItemGroup>
 
 </Project>

--- a/CsharpExample/CompanyReport/Program.cs
+++ b/CsharpExample/CompanyReport/Program.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
-using System.Text.Json;
 using System.Threading.Tasks;
+using CSVFile;
 using LockstepSDK;
-using CsvHelper;
 
 namespace LockstepExamples // Note: actual namespace depends on the project name.
 {
@@ -65,19 +63,13 @@ namespace LockstepExamples // Note: actual namespace depends on the project name
                         ArEmail = company.ArEmailAddress
                     }));
                 }
-                
-                var currentDirectory = Directory.GetCurrentDirectory();
-                const string fileName = "Results.csv";
-                var filePath = $"{currentDirectory}\\..\\..\\..\\{fileName}";
+
+                var filePath = Path.GetTempFileName();
                 
                 try
                 {
-                    Console.WriteLine($"Writing contents to CSV file \"{fileName}\"...");
-                    await using (var writer = new StreamWriter($"{filePath}"))
-                    await using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
-                    {
-                        await csv.WriteRecordsAsync(entries);
-                    }
+                    Console.WriteLine($"Writing contents to CSV file \"{filePath}\"...");
+                    await File.WriteAllTextAsync(filePath, CSV.Serialize(entries));
                     Console.WriteLine($"Successfully created file: {filePath}");
                 }
                 catch (Exception e)

--- a/CsharpExample/ConnectorExample/ConnectorExample.csproj
+++ b/CsharpExample/ConnectorExample/ConnectorExample.csproj
@@ -8,8 +8,8 @@
 
     <ItemGroup>
       <PackageReference Include="CommandLineParser" Version="2.8.0" />
-      <PackageReference Include="CsvHelper" Version="27.2.1" />
-      <PackageReference Include="LockstepSdk" Version="2022.9.56" />
+      <PackageReference Include="CSVFile" Version="3.0.9" />
+      <PackageReference Include="LockstepSdk" Version="2022.11.60" />
       <PackageReference Include="SSH.NET" Version="2020.0.1" />
     </ItemGroup>
 

--- a/CsharpExample/ConnectorExample/ModelConverter.cs
+++ b/CsharpExample/ConnectorExample/ModelConverter.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
+using System.Threading.Tasks;
 using System.Xml;
-using CsvHelper;
+using CSVFile;
 using LockstepSDK;
 
 namespace LockstepExamples
@@ -15,16 +15,14 @@ namespace LockstepExamples
             return System.Array.Empty<InvoiceSyncModel>();
         }
         
-        public static string SaveBatchToCsv(IEnumerable<InvoiceSyncModel> list, string filename)
+        public static async Task<string> SaveBatchToCsv(IEnumerable<InvoiceSyncModel> list, string filename)
         {
             var filePath = Path.Combine(Path.GetTempPath(), filename);
             if (File.Exists(filePath))
             {
                 File.Delete(filePath);
             }
-            using var writer = new StreamWriter(filePath);
-            using var csvWriter = new CsvWriter(writer, CultureInfo.InvariantCulture);
-            csvWriter.WriteRecords(list);
+            await File.WriteAllTextAsync(filePath, CSV.Serialize(list));
             return filePath;
         }
     }

--- a/CsharpExample/ConnectorExample/Program.cs
+++ b/CsharpExample/ConnectorExample/Program.cs
@@ -24,7 +24,7 @@ namespace LockstepExamples
                         var invoices = ModelConverter.ConvertInvoices(invoiceXml);
                         
                         // Save invoices to CSV files
-                        var filenames = new List<string> { ModelConverter.SaveBatchToCsv(invoices, "invoices.csv") };
+                        var filenames = new List<string> { await ModelConverter.SaveBatchToCsv(invoices, "invoices.csv") };
 
                         // Let's convert them to the Lockstep SFTP format
                         var zipArchiveName = $"{DateTime.Today:yyyy-MM-dd}_batch.zip";

--- a/CsharpExample/CsharpExample.sln
+++ b/CsharpExample/CsharpExample.sln
@@ -15,8 +15,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Other Items", "Other Items"
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LockstepSDK.NetStandard20", "..\..\lockstep-sdk-csharp\src\netstandard20\LockstepSDK.NetStandard20.csproj", "{E417E40D-3E2E-4395-ACDC-0420E2BC8A70}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,9 +41,5 @@ Global
 		{E395C885-B852-4BD1-998D-51153CC93E95}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E395C885-B852-4BD1-998D-51153CC93E95}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E395C885-B852-4BD1-998D-51153CC93E95}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E417E40D-3E2E-4395-ACDC-0420E2BC8A70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E417E40D-3E2E-4395-ACDC-0420E2BC8A70}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E417E40D-3E2E-4395-ACDC-0420E2BC8A70}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E417E40D-3E2E-4395-ACDC-0420E2BC8A70}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/CsharpExample/CsharpExample/CsharpExample.csproj
+++ b/CsharpExample/CsharpExample/CsharpExample.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="LockstepSdk" Version="2022.9.56" />
+      <PackageReference Include="LockstepSdk" Version="2022.11.60" />
     </ItemGroup>
 
 </Project>

--- a/CsharpExample/PerformanceTest/PerformanceTest.csproj
+++ b/CsharpExample/PerformanceTest/PerformanceTest.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="LockstepSdk" Version="2022.9.56" />
+      <PackageReference Include="LockstepSdk" Version="2022.11.60" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Let's update them to the latest build and clean up some unnecessary stuff.  Rather than using relative paths, we'll use the system's temporary file name service.