### PR TITLE
Python sdk type annotations

### DIFF
--- a/SdkGenerator/SdkGenerator/PythonSdk.cs
+++ b/SdkGenerator/SdkGenerator/PythonSdk.cs
@@ -27,7 +27,7 @@ public static class PythonSdk
                + "#\n\n";
     }
 
-    private static string FixupType(ApiSchema api, string typeName, bool isArray, bool isLockstepResponse = false)
+    private static string FixupType(ApiSchema api, string typeName, bool isArray, bool preserveType = false)
     {
         var s = typeName;
         if (api.IsEnum(typeName))
@@ -75,7 +75,7 @@ public static class PythonSdk
             return s;
         }
 
-        if (!isLockstepResponse)
+        if (!preserveType)
         {
             s = "object";
         }
@@ -214,7 +214,7 @@ public static class PythonSdk
 
                     // Figure out the parameter list
                     var hasBody = (from p in endpoint.Parameters where p.Location == "body" select p).Any();
-                    var paramListStr = string.Join(", ", from p in endpoint.Parameters select $"{p.Name}: {FixupType(api, p.DataType, p.IsArray)}");
+                    var paramListStr = string.Join(", ", from p in endpoint.Parameters select $"{p.Name}: {FixupType(api, p.DataType, p.IsArray, preserveType: true)}");
                     var bodyJson = string.Join(", ", from p in endpoint.Parameters where p.Location == "query" select $"\"{p.Name}\": {p.Name}");
                     var fileUploadParam = (from p in endpoint.Parameters where p.Location == "form" select p).FirstOrDefault();
 
@@ -351,7 +351,7 @@ public static class PythonSdk
             sb.AppendLine($"{prefix}----------");
             foreach (var p in parameters)
             {
-                sb.AppendLine($"{prefix}{p.Name} : {FixupType(api, p.DataType, p.IsArray)}");
+                sb.AppendLine($"{prefix}{p.Name} : {FixupType(api, p.DataType, p.IsArray, preserveType: true)}");
                 sb.AppendLine(p.DescriptionMarkdown.WrapMarkdown(72, $"{prefix}    "));
             }
         }

--- a/SdkGenerator/SdkGenerator/PythonSdk.cs
+++ b/SdkGenerator/SdkGenerator/PythonSdk.cs
@@ -27,7 +27,7 @@ public static class PythonSdk
                + "#\n\n";
     }
 
-    private static string FixupType(ApiSchema api, string typeName, bool isArray)
+    private static string FixupType(ApiSchema api, string typeName, bool isArray, bool isLockstepResponse = false)
     {
         var s = typeName;
         if (api.IsEnum(typeName))
@@ -69,14 +69,20 @@ public static class PythonSdk
                 break;
         }
 
-        if (isArray)
-        {
-            s = "list[" + s + "]";
-        }
-
         if (s.EndsWith("FetchResult") && !s.EndsWith("SummaryFetchResult"))
         {
             s = $"FetchResult[{s[..^11]}]";
+            return s;
+        }
+
+        if (!isLockstepResponse)
+        {
+            s = "object";
+        }
+
+        if (isArray)
+        {
+            s = "list[" + s + "]";
         }
 
         return s;
@@ -102,12 +108,6 @@ public static class PythonSdk
 
                 // Add in all the rest of the imports
                 sb.AppendLine("from dataclasses import dataclass");
-                foreach (var f in item.Fields.Where(f => f.DataTypeRef != null && f.DataType != item.Name))
-                {
-                    sb.AppendLine(
-                        $"from {project.Python.Namespace}.models.{f.DataType.ToSnakeCase()} import {f.DataType}");
-                }
-
                 sb.AppendLine();
                 sb.AppendLine("@dataclass");
                 sb.AppendLine($"class {item.Name}:");
@@ -120,6 +120,21 @@ public static class PythonSdk
 
                 sb.AppendLine();
 
+                if (item.Name.Equals("ErrorResult", StringComparison.OrdinalIgnoreCase))
+                {
+                    sb.AppendLine($"    @classmethod");
+                    sb.AppendLine($"    def from_json(cls, data: dict):");
+                    sb.AppendLine($"        obj = cls()");
+                    sb.AppendLine($"        for key, value in data.items():");
+                    sb.AppendLine($"            if hasattr(obj, key):");
+                    sb.AppendLine($"                setattr(obj, key, value)");
+                    sb.AppendLine($"        return obj");
+                }
+
+                // Add helper methods for users to serialize objects
+                sb.AppendLine($"    def to_dict(self) -> dict:");
+                sb.AppendLine($"        return dataclass.asdict(self)");
+
                 var modelPath = Path.Combine(modelsDir, item.Name.ToSnakeCase() + ".py");
                 await File.WriteAllTextAsync(modelPath, sb.ToString());
             }
@@ -129,19 +144,19 @@ public static class PythonSdk
     private static async Task CleanModuleDirectory(string pyModuleDir)
     {
         Directory.CreateDirectory(pyModuleDir);
-        
+
         var initFile = Path.Combine(pyModuleDir, "__init__.py");
         if (!File.Exists(initFile))
         {
             await File.Create(initFile).DisposeAsync();
         }
-        
+
         foreach (var pyFile in Directory.EnumerateFiles(pyModuleDir, "*.py").Where(f => !f.EndsWith("__init__.py")))
         {
             File.Delete(pyFile);
         }
     }
-    
+
     private static async Task ExportEndpoints(ProjectSchema project, ApiSchema api)
     {
         var clientsDir = Path.Combine(project.Python.Folder, "src", project.Python.Namespace, "clients");
@@ -185,7 +200,8 @@ public static class PythonSdk
 
                     // Is this a file download API?
                     var isFileDownload = endpoint.ReturnDataType.DataType is "byte[]" or "binary" or "File";
-                    var originalReturnDataType = FixupType(api, endpoint.ReturnDataType.DataType, endpoint.ReturnDataType.IsArray);
+                    var originalReturnDataType = FixupType(api, endpoint.ReturnDataType.DataType,
+                        endpoint.ReturnDataType.IsArray, true);
                     string returnDataType;
                     if (!isFileDownload)
                     {
@@ -217,11 +233,28 @@ public static class PythonSdk
                     else
                     {
                         sb.AppendLine("        if result.status_code >= 200 and result.status_code < 300:");
-                        sb.AppendLine(
-                            $"            return {project.Python.ResponseClass}(True, result.status_code, {originalReturnDataType}(**result.json()), None)");
+                        if (originalReturnDataType.StartsWith("list", StringComparison.OrdinalIgnoreCase))
+                        {
+                            // Use a list comprehension to unpack array responses
+                            sb.AppendLine(
+                                $"            return {project.Python.ResponseClass}(True, result.status_code, [{endpoint.ReturnDataType.DataType}(**item) for item in result.json()], None)");
+                        }
+                        else if (originalReturnDataType.StartsWith("FetchResult", StringComparison.OrdinalIgnoreCase))
+                        {
+                            // Fetch results don't unpack as expected, use from_json helper method
+                            sb.AppendLine(
+                                $"            return {project.Python.ResponseClass}(True, result.status_code, FetchResult.from_json(result.json(), {endpoint.ReturnDataType.DataType[..^11]}), None)");                            
+                            Console.WriteLine("halp");
+                        }
+                        else
+                        {
+                            sb.AppendLine(
+                                $"            return {project.Python.ResponseClass}(True, result.status_code, {originalReturnDataType}(**result.json()), None)");
+                        }
+
                         sb.AppendLine("        else:");
                         sb.AppendLine(
-                            $"            return {project.Python.ResponseClass}(False, result.status_code, None, ErrorResult(**result.json()))");
+                            $"            return {project.Python.ResponseClass}(False, result.status_code, None, ErrorResult.from_json(result.json()))");
                     }
                 }
             }

--- a/SdkGenerator/SdkGenerator/PythonSdk.cs
+++ b/SdkGenerator/SdkGenerator/PythonSdk.cs
@@ -85,11 +85,7 @@ public static class PythonSdk
     private static async Task ExportSchemas(ProjectSchema project, ApiSchema api)
     {
         var modelsDir = Path.Combine(project.Python.Folder, "src", project.Python.Namespace, "models");
-        Directory.CreateDirectory(modelsDir);
-        foreach (var modelFile in Directory.EnumerateFiles(modelsDir, "*.py"))
-        {
-            File.Delete(modelFile);
-        }
+        await CleanModuleDirectory(modelsDir);
 
         foreach (var item in api.Schemas)
         {
@@ -130,14 +126,26 @@ public static class PythonSdk
         }
     }
 
+    private static async Task CleanModuleDirectory(string pyModuleDir)
+    {
+        Directory.CreateDirectory(pyModuleDir);
+        
+        var initFile = Path.Combine(pyModuleDir, "__init__.py");
+        if (!File.Exists(initFile))
+        {
+            await File.Create(initFile).DisposeAsync();
+        }
+        
+        foreach (var pyFile in Directory.EnumerateFiles(pyModuleDir, "*.py").Where(f => !f.EndsWith("__init__.py")))
+        {
+            File.Delete(pyFile);
+        }
+    }
+    
     private static async Task ExportEndpoints(ProjectSchema project, ApiSchema api)
     {
         var clientsDir = Path.Combine(project.Python.Folder, "src", project.Python.Namespace, "clients");
-        Directory.CreateDirectory(clientsDir);
-        foreach (var clientFile in Directory.EnumerateFiles(clientsDir, "*.py"))
-        {
-            File.Delete(clientFile);
-        }
+        await CleanModuleDirectory(clientsDir);
 
         // Gather a list of unique categories
         foreach (var cat in api.Categories)


### PR DESCRIPTION
This PR makes some updates to the current code generation for the Python SDK.
* Ensure sub module directories have a `__init__.py` file
  * The build process wasn't recognizing `models/` as a sub-module, therefore not including in the package
* Add `from_json` helper methods to `ErrorResult` and `FetchResult` to allow object unpacking with ** operator
* Update return type construction for array types to use list comprehension
* Use generic object for nested class properties to avoid circular reference errors
  * Temporary solution to get client in a running state, not a great long term fix
  * Sacrifices the benefits of type annotations
  * A more robust solution would be required to fully support forward referenced type annotations
 
Updated code can also be found on my [under py-generator-updates on my fork.](https://github.com/sfwatanabe/lockstep-sdk-python/tree/py-generator-updates)