### PR TITLE
Skip null return data types

### DIFF
--- a/SdkGenerator/SdkGenerator/CSharpSdk.cs
+++ b/SdkGenerator/SdkGenerator/CSharpSdk.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -255,7 +255,7 @@ public static class CSharpSdk
             // Run through all APIs
             foreach (var endpoint in api.Endpoints)
             {
-                if (endpoint.Category == cat && !endpoint.Deprecated)
+                if (endpoint.Category == cat && !endpoint.Deprecated && endpoint.ReturnDataType != null)
                 {
                     sb.AppendLine();
                     sb.Append(MarkdownToDocblock(endpoint.DescriptionMarkdown, 8, endpoint.Parameters));

--- a/SdkGenerator/SdkGenerator/JavaSdk.cs
+++ b/SdkGenerator/SdkGenerator/JavaSdk.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -222,7 +222,7 @@ public static class JavaSdk
             // Run through all APIs
             foreach (var endpoint in api.Endpoints)
             {
-                if (endpoint.Category == cat && !endpoint.Deprecated)
+                if (endpoint.Category == cat && !endpoint.Deprecated && endpoint.ReturnDataType != null)
                 {
                     sb.AppendLine();
                     sb.Append(endpoint.DescriptionMarkdown.ToJavaDoc(4,
@@ -318,7 +318,7 @@ public static class JavaSdk
         var types = new HashSet<string>();
         foreach (var endpoint in api.Endpoints)
         {
-            if (endpoint.Category == category && !endpoint.Deprecated)
+            if (endpoint.Category == category && !endpoint.Deprecated && endpoint.ReturnDataType != null)
             {
                 AddImport(api, endpoint.ReturnDataType.DataType, types);
                 foreach (var p in endpoint.Parameters)

--- a/SdkGenerator/SdkGenerator/PythonSdk.cs
+++ b/SdkGenerator/SdkGenerator/PythonSdk.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -201,7 +201,7 @@ public static class PythonSdk
             // Run through all APIs
             foreach (var endpoint in api.Endpoints)
             {
-                if (endpoint.Category == cat && !endpoint.Deprecated)
+                if (endpoint.Category == cat && !endpoint.Deprecated && endpoint.ReturnDataType != null)
                 {
                     sb.AppendLine();
 
@@ -276,7 +276,7 @@ public static class PythonSdk
         var imports = new List<string>();
         foreach (var endpoint in api.Endpoints)
         {
-            if (endpoint.Category == cat && !endpoint.Deprecated)
+            if (endpoint.Category == cat && !endpoint.Deprecated && endpoint.ReturnDataType != null)
             {
                 foreach (var p in endpoint.Parameters)
                 {

--- a/SdkGenerator/SdkGenerator/ReadmeUpload.cs
+++ b/SdkGenerator/SdkGenerator/ReadmeUpload.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -110,7 +110,7 @@ public static class ReadmeUpload
 
         // Link all the API endpoints that work with this model
         var methods = new List<string>();
-        foreach (var endpoint in api.Endpoints)
+        foreach (var endpoint in api.Endpoints.Where(e => e.ReturnDataType != null))
         {
             var endpointDataType = endpoint.ReturnDataType.DataType.Replace("FetchResult", "");
             if (endpointDataType == item.Name)

--- a/SdkGenerator/SdkGenerator/Schema/SchemaFactory.cs
+++ b/SdkGenerator/SdkGenerator/Schema/SchemaFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -308,12 +308,14 @@ public static class SchemaFactory
             {
                 if (response.Name.StartsWith("2"))
                 {
-                    response.Value.TryGetProperty("content", out var contentProp);
-                    contentProp.TryGetProperty("application/json", out var appJsonProp);
-                    foreach (var responseSchemaProp in appJsonProp.EnumerateObject())
+                    if (response.Value.TryGetProperty("content", out var contentProp))
                     {
-                        item.ReturnDataType = GetTypeRef(responseSchemaProp);
-                        break;
+                        contentProp.TryGetProperty("application/json", out var appJsonProp);
+                        foreach (var responseSchemaProp in appJsonProp.EnumerateObject())
+                        {
+                            item.ReturnDataType = GetTypeRef(responseSchemaProp);
+                            break;
+                        }
                     }
                 }
             }

--- a/SdkGenerator/SdkGenerator/TypescriptSdk.cs
+++ b/SdkGenerator/SdkGenerator/TypescriptSdk.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -167,7 +167,7 @@ public static class TypescriptSdk
             // Run through all APIs
             foreach (var endpoint in api.Endpoints)
             {
-                if (endpoint.Category == cat && !endpoint.Deprecated)
+                if (endpoint.Category == cat && !endpoint.Deprecated && endpoint.ReturnDataType != null)
                 {
                     sb.AppendLine();
                     sb.Append(endpoint.DescriptionMarkdown.ToJavaDoc(2, null, endpoint.Parameters));
@@ -253,7 +253,7 @@ public static class TypescriptSdk
         var types = new List<string>();
         foreach (var endpoint in api.Endpoints)
         {
-            if (endpoint.Category == category && !endpoint.Deprecated)
+            if (endpoint.Category == category && !endpoint.Deprecated && endpoint.ReturnDataType != null)
             {
                 AddImport(api, endpoint.ReturnDataType.DataType, types);
                 foreach (var p in endpoint.Parameters)


### PR DESCRIPTION
We've added new API endpoints that do not return a response body.

For now, they will be ignored.